### PR TITLE
Fix GitHub Actions deployment failure

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.146.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Summary
- Fixed Hugo deployment failure by updating Hugo version to 0.146.0
- The PaperMod theme requires minimum Hugo v0.146.0 but workflow was using v0.128.0

## Root Cause
The deployment was failing with template errors because:
1. Hugo v0.128.0 was being used in GitHub Actions
2. PaperMod theme requires minimum v0.146.0 
3. This caused missing template partials and render failures

## Fix
- Updated Hugo version from 0.128.0 to 0.146.0 in `.github/workflows/hugo.yml`
- This resolves the theme compatibility issue and template errors

## Test plan
- [x] Identified root cause from GitHub Actions logs
- [x] Updated Hugo version in workflow
- [ ] Verify GitHub Actions workflow passes on this PR
- [ ] Confirm site deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)