### PR TITLE
Configure workflow to build on PRs, deploy only on main

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["main"]
 
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -68,6 +72,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/content/pages/swimming-journey.md
+++ b/content/pages/swimming-journey.md
@@ -5,7 +5,7 @@ date: 2023-02-01T00:00:00Z
 url: "/swimming-journey/"
 ---
 
-This page tracks my journey learning to swim, starting in February 2023. You can read the full story of [how I learned to overcome my fears and start swimming]({{< ref "/writing/2023/learning-to-swim" >}}).
+This page tracks my journey learning to swim, starting in February 2023.
 
 ## Progress Overview
 

--- a/content/writing/2023/learning-to-swim.md
+++ b/content/writing/2023/learning-to-swim.md
@@ -4,6 +4,7 @@ date: 2023-08-28T00:00:00Z
 description: "A deeply personal journey of overcoming submechanophobia, childhood trauma, and learning to swim at age 35. From terror of water tanks to swimming 700m in sessions."
 tags: ["swimming", "life", "health", "fear", "dune", "litany-against-fear", "zee-swim-academy", "submechanophobia", "personal", "growth"]
 categories: ["Life", "Personal"]
+draft: true
 ---
 
 {{< note >}}


### PR DESCRIPTION
## Summary
- Configure GitHub Actions workflow to build on pull requests
- Only deploy to GitHub Pages when merging to main branch
- Fix broken reference link in swimming journey page
- Restore draft status for learning-to-swim post

## Changes
1. **Workflow Updates**:
   - Added `pull_request` trigger for main branch
   - Added conditional deployment (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`)
   - Now builds on every PR to catch issues early

2. **Content Fixes**:
   - Removed broken ref link to draft post in swimming journey page
   - Restored `draft: true` status for learning-to-swim post

## Benefits
- PRs will now run build checks to catch Hugo errors before merging
- Deployment only happens on main branch to prevent unnecessary deploys
- Maintains draft status for unpublished content

## Test plan
- [x] PR should trigger build job but skip deploy job
- [ ] Verify build succeeds without Hugo errors
- [ ] Confirm deploy job is skipped for PR
- [ ] Test that merge to main still triggers both build and deploy

🤖 Generated with [Claude Code](https://claude.ai/code)